### PR TITLE
Update JavaScript client to default to passing on PCM Float

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /obj/Debug
 /bin
 /.vs/config/applicationhost.config
+*.suo


### PR DESCRIPTION
Speech Service now supports PCM float so we should enable this format by default since PCM U8 audio quality is poor.