### PR TITLE
Update - close AudioContext

### DIFF
--- a/speech.1.0.0.js
+++ b/speech.1.0.0.js
@@ -13,8 +13,8 @@
 // 
 // LICENSE
 // -------
-// © 2015 Microsoft. All rights reserved.  
-// This document is provided ìas-isî. Information and views expressed in this document, including URL and other Internet Web site references, may change without notice.  
+// ¬© 2015 Microsoft. All rights reserved.  
+// This document is provided ‚Äúas-is‚Äù. Information and views expressed in this document, including URL and other Internet Web site references, may change without notice.  
 // Some examples depicted herein are provided for illustration only and are fictitious.  No real association or connection is intended or should be inferred. 
 // This document does not provide you with any legal rights to any intellectual property in any Microsoft product. You may copy and use this document for your internal, reference purposes. This 
 // document is confidential and proprietary to Microsoft. It is disclosed and can be used only pursuant to a non-disclosure agreement. 
@@ -388,6 +388,7 @@ var Bing;
         };
         Speech.prototype.stop = function () {
             if (this._currentSource) {
+                this._currentSource.close(); // Needed for continued instances of AudioContext
                 Platform.getCU().done(function (cu) {
                     cu.disconnect();
                 });


### PR DESCRIPTION
Closing the AudioContext when the recording stops fixes the issue of the page reaching "max hardware contexts"